### PR TITLE
Add trailing newline when generating test fixtures

### DIFF
--- a/test/swc-to-babel.js
+++ b/test/swc-to-babel.js
@@ -47,7 +47,7 @@ const update = (a, json) => {
     if (!isUpdate)
         return;
     
-    writeFileSync(`${fixtureDir}/${a}.json`, JSON.stringify(json, null, 4));
+    writeFileSync(`${fixtureDir}/${a}.json`, `${JSON.stringify(json, null, 4)}\n`);
 };
 
 const readJS = (a) => readFileSync(join(`${fixtureDir}/${a}`), 'utf8');


### PR DESCRIPTION
This avoids "no newline at end of file" errors for these files.