### PR TITLE
Fix export default expression.

### DIFF
--- a/lib/swc/index.js
+++ b/lib/swc/index.js
@@ -351,6 +351,11 @@ module.exports.convertGetterSetter = ({node}) => {
 };
 
 module.exports.ExportDefaultDeclaration = ({node}) => {
+    // NOTE: It's possible that we've already processed this
+    // node if it was a export default expression. If so, we
+    // don't want to process it again.
+    if (node.declaration) return;
+
     node.declaration = node.decl;
     node.exportKind = 'value';
     node.assertions = [];

--- a/test/fixture/export.js
+++ b/test/fixture/export.js
@@ -11,3 +11,5 @@ export default 1;
 export default function addCommands() {
     const t = 'hello';
 }
+
+export default () => 1;

--- a/test/fixture/export.json
+++ b/test/fixture/export.json
@@ -74,8 +74,14 @@
             },
             {
                 "type": "ExportDefaultDeclaration",
-                "exportKind": "value",
-                "assertions": []
+                "declaration": {
+                    "extra": {
+                        "raw": "1"
+                    },
+                    "raw": "1",
+                    "type": "NumericLiteral",
+                    "value": 1
+                }
             },
             {
                 "type": "ExportDefaultDeclaration",
@@ -118,6 +124,24 @@
                 },
                 "exportKind": "value",
                 "assertions": []
+            },
+            {
+                "declaration": {
+                    "async": false,
+                    "body": {
+                        "extra": {
+                            "raw": "1"
+                        },
+                        "raw": "1",
+                        "type": "NumericLiteral",
+                        "value": 1
+                    },
+                    "generator": false,
+                    "id": null,
+                    "params": [],
+                    "type": "FunctionDeclaration"
+                },
+                "type": "ExportDefaultDeclaration"
             }
         ],
         "interpreter": null,

--- a/test/fixture/export.json
+++ b/test/fixture/export.json
@@ -75,12 +75,12 @@
             {
                 "type": "ExportDefaultDeclaration",
                 "declaration": {
+                    "type": "NumericLiteral",
+                    "value": 1,
+                    "raw": "1",
                     "extra": {
                         "raw": "1"
-                    },
-                    "raw": "1",
-                    "type": "NumericLiteral",
-                    "value": 1
+                    }
                 }
             },
             {
@@ -126,22 +126,22 @@
                 "assertions": []
             },
             {
+                "type": "ExportDefaultDeclaration",
                 "declaration": {
-                    "async": false,
+                    "type": "FunctionDeclaration",
+                    "params": [],
                     "body": {
+                        "type": "NumericLiteral",
+                        "value": 1,
+                        "raw": "1",
                         "extra": {
                             "raw": "1"
-                        },
-                        "raw": "1",
-                        "type": "NumericLiteral",
-                        "value": 1
+                        }
                     },
+                    "async": false,
                     "generator": false,
-                    "id": null,
-                    "params": [],
-                    "type": "FunctionDeclaration"
-                },
-                "type": "ExportDefaultDeclaration"
+                    "id": null
+                }
             }
         ],
         "interpreter": null,

--- a/test/fixture/keyof.json
+++ b/test/fixture/keyof.json
@@ -28,6 +28,32 @@
                                 "name": "__b"
                             }
                         }
+                    },
+                    "constrain": {
+                        "type": "TsTypeOperator",
+                        "span": {
+                            "start": 128,
+                            "end": 137
+                        },
+                        "op": "keyof",
+                        "typeAnnotation": {
+                            "type": "TsTypeReference",
+                            "span": {
+                                "start": 134,
+                                "end": 137
+                            },
+                            "typeName": {
+                                "type": "Identifier",
+                                "span": {
+                                    "start": 134,
+                                    "end": 137
+                                },
+                                "ctxt": 1,
+                                "value": "__c",
+                                "optional": false
+                            },
+                            "typeParams": null
+                        }
                     }
                 }
             }

--- a/test/fixture/type-alias-declaration.json
+++ b/test/fixture/type-alias-declaration.json
@@ -29,6 +29,32 @@
                                 "name": "Key"
                             }
                         }
+                    },
+                    "constrain": {
+                        "type": "TsTypeOperator",
+                        "span": {
+                            "start": 670,
+                            "end": 680
+                        },
+                        "op": "keyof",
+                        "typeAnnotation": {
+                            "type": "TsTypeReference",
+                            "span": {
+                                "start": 676,
+                                "end": 680
+                            },
+                            "typeName": {
+                                "type": "Identifier",
+                                "span": {
+                                    "start": 676,
+                                    "end": 680
+                                },
+                                "ctxt": 1,
+                                "value": "Type",
+                                "optional": false
+                            },
+                            "typeParams": null
+                        }
                     }
                 }
             },
@@ -57,6 +83,32 @@
                                 "type": "Identifier",
                                 "name": "__b"
                             }
+                        }
+                    },
+                    "constrain": {
+                        "type": "TsTypeOperator",
+                        "span": {
+                            "start": 717,
+                            "end": 726
+                        },
+                        "op": "keyof",
+                        "typeAnnotation": {
+                            "type": "TsTypeReference",
+                            "span": {
+                                "start": 723,
+                                "end": 726
+                            },
+                            "typeName": {
+                                "type": "Identifier",
+                                "span": {
+                                    "start": 723,
+                                    "end": 726
+                                },
+                                "ctxt": 1,
+                                "value": "__c",
+                                "optional": false
+                            },
+                            "typeParams": null
                         }
                     }
                 }


### PR DESCRIPTION
Was experimenting and realized the `ExportDefaultExpression` was being overwritten by `ExportDefaultDeclaration` later on - this fixes that by ensuring that we don't re-process the node if we've already handled it.

(It's possible that we may want to ensure that we never re-process any node, maybe using a Set? But figured this was the simplest solution, for now.)